### PR TITLE
Fixes ChesslibMoveData returns wrong rook index for queen side castling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 		<dependency>
 			<groupId>com.fathzer</groupId>
 			<artifactId>chess-utils</artifactId>
-			<version>0.0.3-SNAPSHOT</version>
+			<version>0.0.4-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fathzer</groupId>

--- a/src/main/java/com/fathzer/jchess/chesslib/ChessLibMoveData.java
+++ b/src/main/java/com/fathzer/jchess/chesslib/ChessLibMoveData.java
@@ -75,7 +75,7 @@ public class ChessLibMoveData implements MoveData<Move, ChessLibMoveGenerator> {
 				final Side side = board.getBoard().getSideToMove();
 				this.captured = null;
 				this.movingDestination = move.getTo();
-				final Move rookMove = context.getRookCastleMove(side, context.isCastleMove(move) ? KING_SIDE :
+				final Move rookMove = context.getRookCastleMove(side, context.isKingSideCastle(move) ? KING_SIDE :
                     QUEEN_SIDE);
 				this.castlingRookIndex = rookMove.getFrom();
 				this.castlingRookDestinationIndex = rookMove.getTo();


### PR DESCRIPTION
Fixes issue #2 